### PR TITLE
Fix kinematics_interface version to 1.1.0 (API break from 1.2.0)

### DIFF
--- a/cartesian_controllers_ros2.repos
+++ b/cartesian_controllers_ros2.repos
@@ -3,3 +3,8 @@ repositories:
         type: git
         url: https://github.com/tpoignonec/dynamics_interface.git
         version: main
+
+    external/ros-controls/kinematics_interface:
+        type: git
+        url: https://github.com/ros-controls/kinematics_interface.git
+        version: 1.1.0


### PR DESCRIPTION
The [kinematics_interface](https://github.com/ros-controls/kinematics_interface) version [1.2.0](https://github.com/ros-controls/kinematics_interface/tree/1.2.0) is API breaking (see [PR#83](https://github.com/ros-controls/kinematics_interface/pull/83)).

However, the [dynamics_interface](https://github.com/tpoignonec/dynamics_interface) inherits from the kinematics interface, hence resulting in a broken package.

The change is limited to the `initialize()` function and a change will be necessary.
However, a temporary solution consists in cloning the kinematics_interface version 1.1.0.
The VCS file has been updated in consequence.
